### PR TITLE
Add WGPU backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,3 +44,6 @@ futures-lite = "1.13.0"
 image = { version = "0.24.5", default-features = false, features = ["png"] }
 tracing = { version = "0.1.37", features = ["log"] }
 winit = { version = "0.28.1", default-features = false, features = ["x11"] }
+
+[patch.crates-io]
+piet-wgpu = { path = "../piet-hardware/crates/piet-wgpu" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,31 +12,35 @@ cosmic-text = { version = "0.8.0", default-features = false, features = ["std", 
 glow = { version = "0.12.1", optional = true }
 piet = { version = "0.6.2", default-features = false }
 piet-cosmic-text = "0.2.0"
-piet-glow = { version = "0.1.0" }
+piet-glow = { version = "0.1.0", optional = true }
+piet-wgpu = { version = "0.1.0", default-features = false, optional = true }
 raw-window-handle = "0.5.0"
 softbuffer = "0.2.0"
 tiny-skia = { version = "0.8.3", default-features = false, features = ["std"] }
 tiny-skia-path = "0.8.3"
 tinyvec = { version = "1.6.0", default-features = false, features = ["alloc"] }
 tracing = { version = "0.1.37", default-features = false }
+wgpu0 = { package = "wgpu", version = "0.16.0", default-features = false, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 glutin = { version = "0.30.6", default-features = false, optional = true, features = ["egl"] }
 
 [features]
-default = ["gl", "x11", "wayland", "egl", "glx", "wgl"]
-gl = ["glow", "glutin"]
+default = ["gl", "x11", "wayland", "egl", "glx", "wgl", "wgpu"]
+gl = ["glow", "glutin", "piet-glow"]
 x11 = ["glutin?/x11", "softbuffer/x11"]
 wayland = ["glutin?/wayland", "softbuffer/wayland"]
 egl = ["gl", "glutin/egl"]
 glx = ["gl", "glutin/glx"]
 wgl = ["gl", "glutin/wgl"]
+wgpu = ["piet-wgpu", "wgpu0"]
 
 [build-dependencies]
 cfg_aliases = "0.1.1"
 
 [dev-dependencies]
 env_logger = { version = "0.10.0", default-features = false, features = ["color"] }
+futures-lite = "1.13.0"
 image = { version = "0.24.5", default-features = false, features = ["png"] }
 tracing = { version = "0.1.37", features = ["log"] }
 winit = { version = "0.28.1", default-features = false, features = ["x11"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ tiny-skia = { version = "0.8.3", default-features = false, features = ["std"] }
 tiny-skia-path = "0.8.3"
 tinyvec = { version = "1.6.0", default-features = false, features = ["alloc"] }
 tracing = { version = "0.1.37", default-features = false }
-wgpu0 = { package = "wgpu", version = "0.16.0", default-features = false, optional = true }
+wgpu0 = { package = "wgpu", version = "0.15.0", default-features = false, optional = true }
 
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
 glutin = { version = "0.30.6", default-features = false, optional = true, features = ["egl"] }

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -28,6 +28,7 @@ fn main() -> ! {
 
     // Create the display.
     let mut display = {
+        #[allow(unused_mut)]
         let mut display = Display::builder();
 
         // Uncomment this to force software rendering.

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -299,11 +299,10 @@ fn main() -> ! {
 
                 // Create a new theo surface.
                 let size = window.inner_size();
-                let surface = unsafe {
-                    display
-                        .make_surface(&window, size.width, size.height)
-                        .expect("Failed to create surface")
-                };
+                let surface = futures_lite::future::block_on(unsafe {
+                    display.make_surface(&window, size.width, size.height)
+                })
+                .expect("Failed to create surface");
 
                 // Save the state.
                 state = Some((window, surface));

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -34,6 +34,8 @@ fn main() -> ! {
         // Uncomment this to force software rendering.
         //display = display.force_swrast(true);
 
+        display = display.transparent(false);
+
         // On Windows, we should set up a window first. Otherwise, the GL features
         // we want to use won't be available.
         #[cfg(windows)]
@@ -251,7 +253,7 @@ fn main() -> ! {
                 .text()
                 .new_text_layout(fps_string)
                 .font(FontFamily::SERIF, 24.0)
-                .text_color(piet::Color::rgb8(0x11, 0x22, 0x22))
+                .text_color(piet::Color::BLACK)
                 .build()
                 .unwrap();
 

--- a/src/desktop_gl.rs
+++ b/src/desktop_gl.rs
@@ -217,7 +217,7 @@ impl Display {
         None
     }
 
-    pub(super) unsafe fn make_surface(
+    pub(super) async unsafe fn make_surface(
         &mut self,
         raw: RawWindowHandle,
         width: u32,

--- a/src/desktop_gl.rs
+++ b/src/desktop_gl.rs
@@ -21,7 +21,7 @@
 //! context.
 
 use super::text::{TextInner, TextLayoutInner};
-use super::{DisplayBuilder, Error, ResultExt, Text, TextLayout};
+use super::{DisplayBuilder, Error, ResultExt, SwitchToSwrast, Text, TextLayout};
 
 use glutin::config::{Config, ConfigTemplateBuilder};
 use glutin::context::{
@@ -37,7 +37,6 @@ use piet::{RenderContext as _, StrokeStyle};
 use piet_glow::GlContext;
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
 
-use std::fmt;
 use std::num::NonZeroU32;
 use std::ptr::NonNull;
 
@@ -532,17 +531,3 @@ impl Drop for ContextScope<'_> {
         );
     }
 }
-
-#[derive(Debug)]
-struct SwitchToSwrast;
-
-impl fmt::Display for SwitchToSwrast {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(
-            f,
-            "Switching to software rendering, this may cause lower performance"
-        )
-    }
-}
-
-impl std::error::Error for SwitchToSwrast {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,20 +370,23 @@ macro_rules! make_dispatch {
                 let mut last_error;
 
                 $(
-                    match <$display>::new(&mut self, raw) {
-                        Ok(display) => {
-                            tracing::trace!("Created `{}` display", stringify!($name));
-                            return Ok(DisplayDispatch::$name(display).into());
-                        },
+                    $(#[$meta])*
+                    {
+                        match <$display>::new(&mut self, raw) {
+                            Ok(display) => {
+                                tracing::trace!("Created `{}` display", stringify!($name));
+                                return Ok(DisplayDispatch::$name(display).into());
+                            },
 
-                        Err(e) => {
-                            tracing::warn!(
-                                "Failed to create `{}` display: {}",
-                                stringify!($name),
-                                e
-                            );
+                            Err(e) => {
+                                tracing::warn!(
+                                    "Failed to create `{}` display: {}",
+                                    stringify!($name),
+                                    e
+                                );
 
-                            last_error = e;
+                                last_error = e;
+                            }
                         }
                     }
                 )*

--- a/src/swrast.rs
+++ b/src/swrast.rs
@@ -176,7 +176,7 @@ impl Display {
         })
     }
 
-    pub(super) unsafe fn make_surface(
+    pub(super) async unsafe fn make_surface(
         &mut self,
         raw: RawWindowHandle,
         _width: u32,

--- a/src/wgpu.rs
+++ b/src/wgpu.rs
@@ -1,0 +1,396 @@
+// SPDX-License-Identifier: LGPL-3.0-or-later OR MPL-2.0
+// This file is a part of `theo`.
+//
+// `theo` is free software: you can redistribute it and/or modify it under the terms of
+// either:
+//
+// * GNU Lesser General Public License as published by the Free Software Foundation, either
+// version 3 of the License, or (at your option) any later version.
+// * Mozilla Public License as published by the Mozilla Foundation, version 2.
+//
+// `theo` is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
+// without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+// See the GNU Lesser General Public License or the Mozilla Public License for more details.
+//
+// You should have received a copy of the GNU Lesser General Public License and the Mozilla
+// Public License along with `theo`. If not, see <https://www.gnu.org/licenses/>.
+
+//! The `wgpu` backend.
+
+use crate::text::{Text, TextInner};
+use crate::{DisplayBuilder, Error, ResultExt, SwitchToSwrast};
+
+use piet::kurbo::{Point, Rect, Shape};
+use piet::{RenderContext as _, StrokeStyle};
+use piet_wgpu::{DeviceAndQueue, WgpuContext};
+use raw_window_handle::{
+    HasRawDisplayHandle, HasRawWindowHandle, RawDisplayHandle, RawWindowHandle,
+};
+
+use std::marker::PhantomData;
+
+/// The display for the `wgpu` backend.
+pub(super) struct Display {
+    /// The instance.
+    instance: wgpu::Instance,
+
+    /// The underlying raw display handle.
+    raw: RawDisplayHandle,
+
+    /// Do we support transparency?
+    supports_transparency: bool,
+
+    /// The list of known adapters.
+    adapters: Vec<wgpu::Adapter>,
+}
+
+/// The surface for the `wgpu` backend.
+pub(super) struct Surface {
+    /// The surface.
+    surface: wgpu::Surface,
+
+    /// Surface configuration.
+    config: wgpu::SurfaceConfiguration,
+
+    /// The WGPU context.
+    context: WgpuContext<WgpuInnards>,
+}
+
+/// The rendering context.
+pub(super) struct RenderContext<'dsp, 'srf> {
+    /// The inner context.
+    inner: piet_wgpu::RenderContext<'srf, WgpuInnards>,
+
+    /// The surface texture.
+    surface_texture: Option<wgpu::SurfaceTexture>,
+
+    /// The text context.
+    text: Text,
+
+    /// We don't use the display.
+    _display: PhantomData<&'dsp mut Display>,
+}
+
+impl Display {
+    pub(super) unsafe fn new(
+        builder: &mut DisplayBuilder,
+        raw: RawDisplayHandle,
+    ) -> Result<Self, Error> {
+        if builder.force_swrast {
+            return Err(Error::BackendError(SwitchToSwrast.into()));
+        }
+
+        // Create the instance.
+        let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
+            backends: wgpu::Backends::all(),
+            dx12_shader_compiler: wgpu::Dx12Compiler::default(),
+        });
+
+        Ok(Self {
+            instance,
+            raw,
+            supports_transparency: builder.transparent,
+            adapters: vec![],
+        })
+    }
+
+    pub(super) fn supports_transparency(&self) -> bool {
+        self.supports_transparency
+    }
+
+    pub(super) fn x11_visual(&self) -> Option<std::ptr::NonNull<()>> {
+        None
+    }
+
+    pub(super) async unsafe fn make_surface(
+        &mut self,
+        raw: RawWindowHandle,
+        width: u32,
+        height: u32,
+    ) -> Result<Surface, Error> {
+        // Create a new surface.
+        let surface = self
+            .instance
+            .create_surface(&RawHandles(self.raw, raw))
+            .piet_err()?;
+
+        // See if we have an adaptor for this surface.
+        let adaptor = if let Some(adapter) = self
+            .adapters
+            .iter()
+            .find(|a| a.is_surface_supported(&surface))
+        {
+            adapter
+        } else {
+            // Request a new adapter.
+            let adapter = self
+                .instance
+                .request_adapter(&wgpu::RequestAdapterOptions {
+                    compatible_surface: Some(&surface),
+                    ..Default::default()
+                })
+                .await
+                .ok_or_else(|| Error::NotSupported)?;
+
+            // Add it to the list of known adapters.
+            self.adapters.push(adapter);
+            self.adapters.last().unwrap()
+        };
+
+        // Create the device and queue.
+        let (device, queue) = adaptor
+            .request_device(
+                &wgpu::DeviceDescriptor {
+                    label: Some("theo device and queue"),
+                    features: wgpu::Features::ADDRESS_MODE_CLAMP_TO_BORDER,
+                    limits: wgpu::Limits::default(),
+                },
+                None,
+            )
+            .await
+            .piet_err()?;
+
+        // Get the surface capabilities.
+        let cap = surface.get_capabilities(adaptor);
+
+        // Create the surface configuration.
+        let format = cap
+            .formats
+            .iter()
+            .find(|format| {
+                matches!(format, wgpu::TextureFormat::Rgba8Unorm)
+                    | matches!(format, wgpu::TextureFormat::Bgra8Unorm)
+            })
+            .or_else(|| cap.formats.first())
+            .ok_or(Error::NotSupported)?;
+        let alpha_mode = cap
+            .alpha_modes
+            .iter()
+            .find(|am| {
+                if self.supports_transparency {
+                    !matches!(
+                        am,
+                        wgpu::CompositeAlphaMode::Opaque
+                            | wgpu::CompositeAlphaMode::Auto
+                            | wgpu::CompositeAlphaMode::Inherit
+                    )
+                } else {
+                    true
+                }
+            })
+            .or_else(|| cap.alpha_modes.first())
+            .ok_or(Error::NotSupported)?;
+        let config = wgpu::SurfaceConfiguration {
+            format: *format,
+            width,
+            height,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            present_mode: *cap.present_modes.first().unwrap(),
+            alpha_mode: *alpha_mode,
+            view_formats: vec![*format],
+        };
+
+        Ok(Surface {
+            surface,
+            config,
+            context: WgpuContext::new(WgpuInnards { device, queue }, *format, 1).piet_err()?,
+        })
+    }
+}
+
+impl<'dsp, 'surf> RenderContext<'dsp, 'surf> {
+    pub(super) unsafe fn new(
+        _display: &'dsp mut Display,
+        surface: &'surf mut Surface,
+        width: u32,
+        height: u32,
+    ) -> Result<Self, Error> {
+        // Create the surface texture.
+        let surface_texture = surface.surface.get_current_texture().piet_err()?;
+
+        // Set the texture size.
+        surface.config.width = width;
+        surface.config.height = height;
+        surface
+            .surface
+            .configure(&surface.context.device_and_queue().device, &surface.config);
+
+        // Create the inner context.
+        let mut inner = surface.context.render_context(
+            surface_texture.texture.create_view(&Default::default()),
+            width,
+            height,
+        );
+
+        Ok(Self {
+            text: Text(TextInner::Wgpu(inner.text().clone())),
+            inner,
+            surface_texture: Some(surface_texture),
+            _display: PhantomData,
+        })
+    }
+
+    pub(super) unsafe fn new_unchecked(
+        display: &'dsp mut Display,
+        surface: &'surf mut Surface,
+        width: u32,
+        height: u32,
+    ) -> Result<Self, Error> {
+        Self::new(display, surface, width, height)
+    }
+
+    pub(super) fn status(&mut self) -> Result<(), Error> {
+        self.inner.status()
+    }
+
+    pub(super) fn solid_brush(&mut self, color: piet::Color) -> Brush {
+        self.inner.solid_brush(color)
+    }
+
+    pub(super) fn gradient(&mut self, gradient: piet::FixedGradient) -> Result<Brush, Error> {
+        self.inner.gradient(gradient)
+    }
+
+    pub(super) fn clear(&mut self, region: Option<Rect>, color: piet::Color) {
+        self.inner.clear(region, color)
+    }
+
+    pub(super) fn stroke(&mut self, shape: impl Shape, brush: &Brush, width: f64) {
+        self.inner.stroke(shape, brush, width)
+    }
+
+    pub(super) fn stroke_styled(
+        &mut self,
+        shape: impl Shape,
+        brush: &Brush,
+        width: f64,
+        style: &StrokeStyle,
+    ) {
+        self.inner.stroke_styled(shape, brush, width, style)
+    }
+
+    pub(super) fn fill(&mut self, shape: impl Shape, brush: &Brush) {
+        self.inner.fill(shape, brush)
+    }
+
+    pub(super) fn fill_even_odd(&mut self, shape: impl Shape, brush: &Brush) {
+        self.inner.fill_even_odd(shape, brush)
+    }
+
+    pub(super) fn clip(&mut self, shape: impl Shape) {
+        self.inner.clip(shape)
+    }
+
+    pub(super) fn text(&mut self) -> &mut Text {
+        &mut self.text
+    }
+
+    pub(super) fn draw_text(&mut self, layout: &crate::text::TextLayout, pos: Point) {
+        match layout.0 {
+            crate::text::TextLayoutInner::Wgpu(ref layout) => self.inner.draw_text(layout, pos),
+
+            _ => panic!("invalid text layout"),
+        }
+    }
+
+    pub(super) fn save(&mut self) -> Result<(), Error> {
+        self.inner.save()
+    }
+
+    pub(super) fn restore(&mut self) -> Result<(), Error> {
+        self.inner.restore()
+    }
+
+    pub(super) fn finish(&mut self) -> Result<(), Error> {
+        self.inner.finish()?;
+
+        // Present the surface texture.
+        self.surface_texture
+            .take()
+            .ok_or(Error::InvalidInput)?
+            .present();
+        Ok(())
+    }
+
+    pub(super) fn transform(&mut self, transform: piet::kurbo::Affine) {
+        self.inner.transform(transform)
+    }
+
+    pub(super) fn make_image(
+        &mut self,
+        width: usize,
+        height: usize,
+        buf: &[u8],
+        format: piet::ImageFormat,
+    ) -> Result<Image, Error> {
+        self.inner.make_image(width, height, buf, format)
+    }
+
+    pub(super) fn draw_image(
+        &mut self,
+        image: &Image,
+        rect: Rect,
+        interp: piet::InterpolationMode,
+    ) {
+        self.inner.draw_image(image, rect, interp)
+    }
+
+    pub(super) fn draw_image_area(
+        &mut self,
+        image: &Image,
+        src_rect: Rect,
+        dst_rect: Rect,
+        interp: piet::InterpolationMode,
+    ) {
+        self.inner
+            .draw_image_area(image, src_rect, dst_rect, interp)
+    }
+
+    pub(super) fn capture_image_area(&mut self, src_rect: Rect) -> Result<Image, Error> {
+        self.inner.capture_image_area(src_rect)
+    }
+
+    pub(super) fn blurred_rect(&mut self, rect: Rect, blur_radius: f64, brush: &Brush) {
+        self.inner.blurred_rect(rect, blur_radius, brush)
+    }
+
+    pub(super) fn current_transform(&self) -> piet::kurbo::Affine {
+        self.inner.current_transform()
+    }
+}
+
+type Brush = piet_wgpu::Brush<WgpuInnards>;
+type Image = piet_wgpu::Image<WgpuInnards>;
+
+/// Combines a raw display handle and a raw window handle.
+struct RawHandles(RawDisplayHandle, RawWindowHandle);
+
+unsafe impl HasRawDisplayHandle for RawHandles {
+    fn raw_display_handle(&self) -> RawDisplayHandle {
+        self.0
+    }
+}
+
+unsafe impl HasRawWindowHandle for RawHandles {
+    fn raw_window_handle(&self) -> RawWindowHandle {
+        self.1
+    }
+}
+
+pub(crate) struct WgpuInnards {
+    /// The device.
+    device: wgpu::Device,
+
+    /// The queue.
+    queue: wgpu::Queue,
+}
+
+impl DeviceAndQueue for WgpuInnards {
+    fn device(&self) -> &wgpu::Device {
+        &self.device
+    }
+
+    fn queue(&self) -> &wgpu::Queue {
+        &self.queue
+    }
+}

--- a/src/wgpu.rs
+++ b/src/wgpu.rs
@@ -176,20 +176,22 @@ impl Display {
                 if self.supports_transparency {
                     matches!(
                         am,
-                        wgpu::CompositeAlphaMode::PreMultiplied
+                        wgpu::CompositeAlphaMode::PostMultiplied
+                            | wgpu::CompositeAlphaMode::Inherit
                     )
                 } else {
-                    true
+                    !matches!(am, wgpu::CompositeAlphaMode::PreMultiplied)
                 }
             })
             .or_else(|| cap.alpha_modes.first())
             .ok_or(Error::NotSupported)?;
+
         let config = wgpu::SurfaceConfiguration {
             format: *format,
             width,
             height,
             usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
-            present_mode: *cap.present_modes.first().unwrap(),
+            present_mode: wgpu::PresentMode::AutoVsync,
             alpha_mode: *alpha_mode,
             view_formats: vec![*format],
         };

--- a/src/wgpu.rs
+++ b/src/wgpu.rs
@@ -180,7 +180,7 @@ impl Display {
                             | wgpu::CompositeAlphaMode::Inherit
                     )
                 } else {
-                    !matches!(am, wgpu::CompositeAlphaMode::PreMultiplied)
+                    true
                 }
             })
             .or_else(|| cap.alpha_modes.first())


### PR DESCRIPTION
Use the `piet-wgpu` crate to power a new WGPU-based backend.

This PR also makes `create_surface` an `async` function.