### PR TITLE
Update backends to use newer software

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,8 +51,8 @@ jobs:
         run: rustup update ${{ matrix.rust }}
       - run: cargo test
       - run: cargo build --all --all-features --all-targets
-      - run: cargo build --no-default-features --features gl,egl,glx,wgl
-      - run: cargo build --no-default-features
+      - run: cargo build --no-default-features --features x11,gl,egl,glx,wgl
+      - run: cargo build --no-default-features --features x11
 
   clippy:
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,8 +31,8 @@ jobs:
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'
       - run: cargo test
       - run: cargo build --all --all-features --all-targets
-      - run: cargo build --no-default-features --features gl,egl,glx,wgl
-      - run: cargo build --no-default-features
+      - run: cargo build --no-default-features --features x11,gl,egl,glx,wgl
+      - run: cargo build --no-default-features --features x11
       - name: Build for wasm32-unknown-unknown
         run: cargo build --target wasm32-unknown-unknown --no-default-features
         if: matrix.os == 'ubuntu-latest' && matrix.rust == 'stable'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,20 +8,18 @@ description = "A standalone renderer for windowing graphics"
 
 [dependencies]
 bytemuck = { version = "1.13.1", default-features = false }
-cosmic-text = { version = "0.8.0", default-features = false, features = ["std", "swash"] }
+cosmic-text = { version = "0.9.0", default-features = false, features = ["std", "swash"] }
 glow = { version = "0.12.1", optional = true }
-line-straddler = "0.1.0"
 piet = { version = "0.6.2", default-features = false }
-piet-cosmic-text = "0.2.0"
 piet-glow = { version = "0.1.0", optional = true }
-piet-wgpu = { version = "0.2.2", default-features = false, optional = true }
+piet-tiny-skia = "0.2.0"
+piet-wgpu = { version = "0.3.0", default-features = false, optional = true }
 raw-window-handle = "0.5.0"
-softbuffer = "0.2.0"
-tiny-skia = { version = "0.8.3", default-features = false, features = ["std"] }
-tiny-skia-path = "0.8.3"
-tinyvec = { version = "1.6.0", default-features = false, features = ["alloc"] }
+slab = { version = "0.4.8", default-features = false, optional = true }
+softbuffer = { version = "0.3.0", default-features = false }
+tiny-skia = { version = "0.11", default-features = false, features = ["std"] }
 tracing = { version = "0.1.37", default-features = false }
-wgpu0 = { package = "wgpu", version = "0.16.0", default-features = false, optional = true }
+wgpu0 = { package = "wgpu", version = "0.17.0", default-features = false, optional = true }
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 glutin = { version = "0.30.6", default-features = false, optional = true, features = ["egl"] }
@@ -41,7 +39,7 @@ wayland = ["glutin?/wayland", "softbuffer/wayland"]
 egl = ["gl", "glutin/egl"]
 glx = ["gl", "glutin/glx"]
 wgl = ["gl", "glutin/wgl"]
-wgpu = ["piet-wgpu", "wgpu0"]
+wgpu = ["piet-wgpu", "wgpu0", "slab"]
 
 [build-dependencies]
 cfg_aliases = "0.1.1"
@@ -51,6 +49,7 @@ env_logger = { version = "0.10.0", default-features = false, features = ["color"
 futures-lite = "1.13.0"
 image = { version = "0.24.5", default-features = false, features = ["png"] }
 instant = "0.1.12"
+softbuffer = { version = "0.3.0", default-features = false, features = ["x11"] }
 tracing = { version = "0.1.37", features = ["log"] }
 winit = { version = "0.28.1", default-features = false, features = ["x11"] }
 

--- a/examples/winit.rs
+++ b/examples/winit.rs
@@ -59,7 +59,7 @@ fn main() -> ! {
         let mut display = Display::builder();
 
         // Uncomment this to force software rendering.
-        display = display.force_swrast(true);
+        //display = display.force_swrast(true);
 
         display = display.transparent(false);
 
@@ -379,6 +379,10 @@ fn main() -> ! {
 
                     // Call to the actual drawing function.
                     draw(&mut render_context).expect("Failed to draw");
+
+                    // As this is our only window, we can just swap buffers now.
+                    drop(render_context);
+                    futures_lite::future::block_on(display.present());
                 }
 
                 next_frame += framerate;

--- a/src/desktop_gl.rs
+++ b/src/desktop_gl.rs
@@ -7,7 +7,6 @@
 // * GNU Lesser General Public License as published by the Free Software Foundation, either
 // version 3 of the License, or (at your option) any later version.
 // * Mozilla Public License as published by the Mozilla Foundation, version 2.
-
 //
 // `theo` is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
@@ -235,6 +234,10 @@ impl Display {
             .piet_err()?;
 
         Ok(Surface { surface })
+    }
+
+    pub(super) async fn present(&mut self) {
+        // no-op
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@
 // * GNU Lesser General Public License as published by the Free Software Foundation, either
 // version 3 of the License, or (at your option) any later version.
 // * Mozilla Public License as published by the Mozilla Foundation, version 2.
-
 //
 // `theo` is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
@@ -1033,6 +1032,18 @@ macro_rules! make_dispatch {
                     )*
                 }
             }
+
+            /// Push the queue and present to all known surfaces.
+            ///
+            /// This is necessary to call after all windows have been drawn to.
+            pub async fn present(&mut self) {
+                match &mut *self.dispatch {
+                    $(
+                        $(#[$meta])*
+                        DisplayDispatch::$name(ctx) => ctx.present().await,
+                    )*
+                }
+            }
         }
 
         impl<'dsp, 'surf> RenderContext<'dsp, 'surf> {
@@ -1409,8 +1420,8 @@ make_dispatch! {
         wgpu_backend::Display,
         wgpu_backend::Surface,
         wgpu_backend::RenderContext<'dsp, 'surf>,
-        piet_wgpu::Brush<wgpu_backend::WgpuInnards>,
-        piet_wgpu::Image<wgpu_backend::WgpuInnards>
+        piet_wgpu::Brush,
+        piet_wgpu::Image
     ),
 
     #[cfg(all(feature = "gl", not(target_arch = "wasm32")))]

--- a/src/swrast.rs
+++ b/src/swrast.rs
@@ -224,6 +224,7 @@ impl<'dsp, 'surf> RenderContext<'dsp, 'surf> {
         &mut self.text
     }
 
+    #[allow(unreachable_patterns)]
     pub(super) fn draw_text(&mut self, layout: &TextLayout, pos: impl Into<Point>) {
         let layout = match &layout.0 {
             TextLayoutInner::Cosmic(ct) => ct,

--- a/src/swrast.rs
+++ b/src/swrast.rs
@@ -7,7 +7,6 @@
 // * GNU Lesser General Public License as published by the Free Software Foundation, either
 // version 3 of the License, or (at your option) any later version.
 // * Mozilla Public License as published by the Mozilla Foundation, version 2.
-
 //
 // `theo` is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
@@ -17,151 +16,70 @@
 // Public License along with `theo`. If not, see <https://www.gnu.org/licenses/>.
 
 //! The software rasterizer backend for `theo`.
-//!
-//! `tiny-skia` is used for rendering, `cosmic-text` is used to layout text, and `ab-glyph`
-//! is used to rasterize glyphs.
+
+use crate::text::TextLayoutInner;
 
 use super::text::{Text, TextLayout};
-use super::{DisplayBuilder, Error, ResultExt};
+use super::{DisplayBuilder, Error};
 
-use piet::kurbo::{Affine, PathEl, Point, Rect, Shape, Size};
-use piet::{
-    FixedGradient, FixedLinearGradient, FixedRadialGradient, ImageFormat, InterpolationMode,
-    LineCap, LineJoin, StrokeStyle,
-};
+use softbuffer as sb;
 
-use cosmic_text::{Color as CosmicColor, LayoutGlyph, SwashCache};
-use line_straddler::{Line as LsLine, LineGenerator, LineType};
-use piet_cosmic_text::Metadata;
+use piet::kurbo::{Affine, Point, Rect, Shape};
+use piet::{FixedGradient, ImageFormat, InterpolationMode, RenderContext as _, StrokeStyle};
+
 use raw_window_handle::{RawDisplayHandle, RawWindowHandle};
-use softbuffer::GraphicsContext;
-use tiny_skia::{ClipMask, ColorU8, FillRule, Paint, PathBuilder, Pixmap, PixmapMut, Shader};
-use tinyvec::TinyVec;
+use tiny_skia::PixmapMut;
 
 use std::mem;
+use std::num::NonZeroU32;
 use std::ptr::NonNull;
 
 /// The display for the software rasterizer.
 pub(super) struct Display {
-    /// The raw display handle.
-    raw: RawDisplayHandle,
+    /// The root display for the backend.
+    root: sb::Context,
 
-    /// The text backend.
-    text: Text,
-
-    /// A cached path builder.
-    path_builder: PathBuilder,
-
-    /// Cache of rasterized glyphs.
-    glyph_cache: SwashCache,
+    /// `piet-tiny-skia`-specific rendering information.
+    cache: piet_tiny_skia::Cache,
 }
 
 /// The surface for the software rasterizer.
 pub(super) struct Surface {
     /// The software rasterizer surface.
-    surface: GraphicsContext,
-
-    /// The buffer that we use for rendering.
-    buffer: Vec<u32>,
+    surface: sb::Surface,
 }
 
 /// The rendering context for the software rasterizer.
 pub(super) struct RenderContext<'dsp, 'surf> {
-    /// The software rasterizer display.
-    display: &'dsp mut Display,
+    /// The underlying context.
+    inner: Option<piet_tiny_skia::RenderContext<'dsp, Buffer<'surf>>>,
 
-    /// The software rasterizer surface.
-    surface: &'surf mut Surface,
-
-    /// The current size of the surface.
-    size: (u32, u32),
-
-    /// The last error that occurred.
-    last_error: Result<(), Error>,
-
-    /// The stack of render states.
-    render_states: TinyVec<[RenderState; 1]>,
-
-    /// The tolerance for curves.
-    tolerance: f64,
+    /// The text interface.
+    text: Text,
 
     /// Whether we currently need to update the render state.
     dirty: bool,
+
+    /// Error from mismatched type usages.
+    mismatch_err: Result<(), piet::Error>,
 }
 
-struct RenderState {
-    /// The current transform.
-    transform: Affine,
-
-    /// The clipping mask.
-    clip: Option<ClipMask>,
+struct Buffer<'a> {
+    buffer: sb::Buffer<'a>,
+    width: u32,
+    height: u32,
 }
 
-impl Default for RenderState {
-    fn default() -> Self {
-        Self {
-            transform: Affine::IDENTITY,
-            clip: None,
-        }
+impl piet_tiny_skia::AsPixmapMut for Buffer<'_> {
+    fn as_pixmap_mut(&mut self) -> PixmapMut<'_> {
+        let (width, height) = (self.width, self.height);
+        PixmapMut::from_bytes(bytemuck::cast_slice_mut(&mut self.buffer), width, height)
+            .expect("This should never fail")
     }
 }
 
-/// The brush used for the software rasterizer.
-#[derive(Clone)]
-pub(super) enum Brush {
-    /// A solid color brush.
-    Solid(piet::Color),
-
-    /// A fixed linear gradient brush.
-    ///
-    /// TODO: Cache the gradient.
-    LinearGradient(FixedLinearGradient),
-
-    /// A fixed radial gradient brush.
-    ///
-    /// TODO: Cache the gradient.
-    RadialGradient(FixedRadialGradient),
-}
-
-impl Brush {
-    fn to_shader(&self) -> Result<Shader<'_>, Error> {
-        match self {
-            Brush::Solid(color) => Ok(Shader::SolidColor(convert_color(*color))),
-            Brush::LinearGradient(linear) => {
-                let start = convert_point(linear.start);
-                let end = convert_point(linear.end);
-                let stops = linear.stops.iter().map(convert_gradient_stop).collect();
-
-                tiny_skia::LinearGradient::new(
-                    start,
-                    end,
-                    stops,
-                    tiny_skia::SpreadMode::Pad,
-                    tiny_skia::Transform::identity(),
-                )
-                .ok_or_else(|| Error::BackendError("failed to create linear gradient".into()))
-            }
-            Brush::RadialGradient(radial) => {
-                let start = convert_point(radial.center);
-                let end = convert_point(radial.center + radial.origin_offset);
-                let stops = radial.stops.iter().map(convert_gradient_stop).collect();
-
-                tiny_skia::RadialGradient::new(
-                    start,
-                    end,
-                    radial.radius as _,
-                    stops,
-                    tiny_skia::SpreadMode::Pad,
-                    tiny_skia::Transform::identity(),
-                )
-                .ok_or_else(|| Error::BackendError("failed to create radial gradient".into()))
-            }
-        }
-    }
-}
-
-/// The image used for the software rasterizer.
-pub(super) struct Image(tiny_skia::Pixmap);
+pub(crate) type Brush = piet_tiny_skia::Brush;
+pub(crate) type Image = piet_tiny_skia::Image;
 
 impl Display {
     pub(super) unsafe fn new(
@@ -169,28 +87,27 @@ impl Display {
         raw: RawDisplayHandle,
     ) -> Result<Self, Error> {
         Ok(Self {
-            raw,
-            text: Text({
-                let text = piet_cosmic_text::Text::new();
-                super::text::TextInner::Cosmic(text)
-            }),
-            path_builder: PathBuilder::new(),
-            glyph_cache: SwashCache::new(),
+            root: sb::Context::from_raw(raw).unwrap(),
+            cache: piet_tiny_skia::Cache::new(),
         })
     }
 
     pub(super) async unsafe fn make_surface(
         &mut self,
         raw: RawWindowHandle,
-        _width: u32,
-        _height: u32,
+        width: u32,
+        height: u32,
     ) -> Result<Surface, Error> {
-        let surface = unsafe { GraphicsContext::from_raw(raw, self.raw) }.piet_err()?;
+        let mut surface = unsafe { sb::Surface::from_raw(&self.root, raw).unwrap() };
 
-        Ok(Surface {
-            surface,
-            buffer: Vec::new(),
-        })
+        surface
+            .resize(
+                NonZeroU32::new(width).unwrap(),
+                NonZeroU32::new(height).unwrap(),
+            )
+            .unwrap();
+
+        Ok(Surface { surface })
     }
 
     pub(super) fn supports_transparency(&self) -> bool {
@@ -201,36 +118,9 @@ impl Display {
         None
     }
 
-    fn path_builder(&mut self) -> PathBuilder {
-        self.path_builder.clear();
-        mem::replace(&mut self.path_builder, PathBuilder::new())
+    pub(super) async fn present(&mut self) {
+        // no-op
     }
-
-    fn cache_path_builder(&mut self, path_builder: PathBuilder) {
-        self.path_builder = path_builder;
-    }
-}
-
-macro_rules! leap {
-    ($self:expr, $e:expr) => {{
-        match $e {
-            Ok(x) => x,
-            Err(err) => {
-                $self.last_error = Err(err);
-                return;
-            }
-        }
-    }};
-    ($self:expr, $e:expr, $err:expr) => {{
-        match $e {
-            Some(x) => x,
-            None => {
-                let err = $err;
-                $self.last_error = Err(Error::BackendError(err.into()));
-                return;
-            }
-        }
-    }};
 }
 
 impl<'dsp, 'surf> RenderContext<'dsp, 'surf> {
@@ -240,22 +130,24 @@ impl<'dsp, 'surf> RenderContext<'dsp, 'surf> {
         width: u32,
         height: u32,
     ) -> Result<Self, Error> {
-        if width == 0 || height == 0 {
-            return Err(Error::InvalidInput);
-        }
+        let width = NonZeroU32::new(width).ok_or(Error::InvalidInput)?;
+        let height = NonZeroU32::new(height).ok_or(Error::InvalidInput)?;
 
-        // Resize the buffer.
-        let len = (width * height) as usize;
-        surface.buffer.resize(len, 0);
+        // Resize the surface.
+        surface.surface.resize(width, height).unwrap();
+
+        // Create the context.
+        let mut context = display.cache.render_context(Buffer {
+            buffer: surface.surface.buffer_mut().unwrap(),
+            width: width.get(),
+            height: height.get(),
+        });
 
         Ok(Self {
-            display,
-            surface,
-            size: (width, height),
-            last_error: Ok(()),
-            render_states: TinyVec::from([Default::default()]),
-            tolerance: 5.0,
-            dirty: true,
+            text: Text(crate::text::TextInner::Cosmic(context.text().clone())),
+            inner: Some(context),
+            dirty: false,
+            mismatch_err: Ok(()),
         })
     }
 
@@ -268,106 +160,38 @@ impl<'dsp, 'surf> RenderContext<'dsp, 'surf> {
         Self::new(display, surface, width, height)
     }
 
-    fn current_state(&self) -> &RenderState {
-        self.render_states.last().unwrap()
-    }
-
-    fn drawing_parts(&mut self) -> (&mut Display, PixmapMut<'_>, &mut RenderState, f64) {
-        let Self {
-            display,
-            surface: Surface { buffer, .. },
-            render_states,
-            size,
-            tolerance,
-            ..
-        } = self;
-
-        let pixmap = PixmapMut::from_bytes(
-            bytemuck::cast_slice_mut(buffer.as_mut_slice()),
-            size.0,
-            size.1,
-        )
-        .expect("There should be no way to create a pixmap with invalid parameters");
-
-        (
-            display,
-            pixmap,
-            render_states.last_mut().expect(STACK_UNBALANCE),
-            *tolerance,
-        )
-    }
-
-    fn fill_rect(&mut self, rect: Rect, shader: Shader<'_>) {
-        let (_, mut buffer, state, ..) = self.drawing_parts();
-
-        let paint = Paint {
-            shader,
-            ..Default::default()
-        };
-
-        let transform = convert_transform(state.transform);
-
-        if convert_rect(rect)
-            .and_then(|rect| buffer.fill_rect(rect, &paint, transform, state.clip.as_ref()))
-            .is_none()
-        {
-            self.last_error = Err(Error::BackendError("Failed to fill rect".into()));
-        }
-
-        self.dirty = true;
-    }
-
-    fn fill_impl(&mut self, shape: impl Shape, brush: &Brush, fill_rule: FillRule) {
-        let mut builder = self.display.path_builder();
-        let (_, mut buffer, state, tolerance) = self.drawing_parts();
-        let paint = Paint {
-            shader: leap!(self, brush.to_shader()),
-            ..Default::default()
-        };
-
-        let transform = convert_transform(state.transform);
-        convert_shape(&mut builder, shape, tolerance, None);
-        let path = leap!(self, builder.finish(), "Failed to build path");
-
-        buffer.fill_path(&path, &paint, fill_rule, transform, state.clip.as_ref());
-
-        self.display.cache_path_builder(path.clear());
-        self.dirty = true;
-    }
-
-    fn size(&self) -> Size {
-        Size::new(self.size.0 as f64, self.size.1 as f64)
+    fn inner(&mut self) -> &mut piet_tiny_skia::RenderContext<'dsp, Buffer<'surf>> {
+        self.inner
+            .as_mut()
+            .expect("Tried to use context after finish()")
     }
 
     pub(super) fn status(&mut self) -> Result<(), Error> {
-        mem::replace(&mut self.last_error, Ok(()))
+        mem::replace(&mut self.mismatch_err, Ok(()))?;
+
+        if let Some(inner) = self.inner.as_mut() {
+            inner.status()
+        } else {
+            Ok(())
+        }
     }
 
     pub(super) fn solid_brush(&mut self, color: piet::Color) -> Brush {
-        Brush::Solid(color)
+        self.inner().solid_brush(color)
     }
 
     pub(super) fn gradient(&mut self, gradient: FixedGradient) -> Result<Brush, Error> {
-        match gradient {
-            FixedGradient::Linear(linear) => Ok(Brush::LinearGradient(linear)),
-            FixedGradient::Radial(radial) => Ok(Brush::RadialGradient(radial)),
-        }
+        self.inner().gradient(gradient)
     }
 
     pub(super) fn clear(&mut self, region: Option<Rect>, color: piet::Color) {
-        if region.is_some() || self.current_state().clip.is_some() {
-            self.fill_rect(
-                region.unwrap_or_else(|| Rect::from_origin_size((0.0, 0.0), self.size())),
-                Shader::SolidColor(convert_color(color)),
-            );
-        } else {
-            let (_, mut buffer, ..) = self.drawing_parts();
-            buffer.fill(convert_color(color));
-        }
+        self.inner().clear(region, color);
+        self.dirty = true;
     }
 
     pub(super) fn stroke(&mut self, shape: impl Shape, brush: &Brush, width: f64) {
-        self.stroke_styled(shape, brush, width, &Default::default())
+        self.inner().stroke(shape, brush, width);
+        self.dirty = true;
     }
 
     pub(super) fn stroke_styled(
@@ -377,231 +201,68 @@ impl<'dsp, 'surf> RenderContext<'dsp, 'surf> {
         width: f64,
         style: &StrokeStyle,
     ) {
-        let mut builder = self.display.path_builder();
-        let (_, mut buffer, state, tolerance) = self.drawing_parts();
-
-        let paint = Paint {
-            shader: leap!(self, brush.to_shader()),
-            ..Default::default()
-        };
-
-        let transform = convert_transform(state.transform);
-
-        convert_shape(&mut builder, shape, tolerance, None);
-        let path = leap!(self, builder.finish(), "Failed to build path");
-
-        // Convert stroke properties.
-        let stroke = tiny_skia::Stroke {
-            width: width as f32,
-            miter_limit: style.miter_limit().map_or(4.0, |limit| limit as f32),
-            line_cap: match style.line_cap {
-                LineCap::Butt => tiny_skia::LineCap::Butt,
-                LineCap::Round => tiny_skia::LineCap::Round,
-                LineCap::Square => tiny_skia::LineCap::Square,
-            },
-            line_join: match style.line_join {
-                LineJoin::Bevel => tiny_skia::LineJoin::Bevel,
-                LineJoin::Round => tiny_skia::LineJoin::Round,
-                LineJoin::Miter { .. } => tiny_skia::LineJoin::Miter,
-            },
-            dash: if style.dash_pattern.is_empty() {
-                None
-            } else {
-                tiny_skia::StrokeDash::new(
-                    style.dash_pattern.iter().map(|&x| x as f32).collect(),
-                    style.dash_offset as f32,
-                )
-            },
-        };
-
-        // Draw the path.
-        buffer.stroke_path(&path, &paint, &stroke, transform, state.clip.as_ref());
-
-        self.display.cache_path_builder(path.clear());
+        self.inner().stroke_styled(shape, brush, width, style);
         self.dirty = true;
     }
 
     pub(super) fn fill(&mut self, shape: impl Shape, brush: &Brush) {
-        self.fill_impl(shape, brush, FillRule::Winding)
+        self.inner().fill(shape, brush);
+        self.dirty = true;
     }
 
     pub(super) fn fill_even_odd(&mut self, shape: impl Shape, brush: &Brush) {
-        self.fill_impl(shape, brush, FillRule::EvenOdd)
+        self.inner().fill_even_odd(shape, brush);
+        self.dirty = true;
     }
 
     pub(super) fn clip(&mut self, shape: impl Shape) {
-        let mut builder = self.display.path_builder();
-        let (width, height) = self.size;
-        let (_, _, state, tolerance) = self.drawing_parts();
-
-        let transform = state.transform;
-        convert_shape(&mut builder, shape, tolerance, Some(transform));
-        let path = match builder.finish() {
-            Some(path) => path,
-            None => {
-                // Empty path.
-                return;
-            }
-        };
-
-        // Either intersect with the current clip or create a new one.
-        match &mut state.clip {
-            Some(ref mut clip) => {
-                clip.intersect_path(&path, tiny_skia::FillRule::EvenOdd, false)
-                    .unwrap();
-            }
-
-            slot @ None => {
-                let mut mask = ClipMask::new();
-                mask.set_path(width, height, &path, tiny_skia::FillRule::EvenOdd, false)
-                    .unwrap();
-                *slot = Some(mask);
-            }
-        }
-
-        self.display.cache_path_builder(path.clear());
+        self.inner().clip(shape);
+        self.dirty = true;
     }
 
     pub(super) fn text(&mut self) -> &mut Text {
-        &mut self.display.text
+        &mut self.text
     }
 
-    #[allow(unreachable_patterns)]
     pub(super) fn draw_text(&mut self, layout: &TextLayout, pos: impl Into<Point>) {
-        let text = self.text().clone();
-        let (display, mut buffer, state, ..) = self.drawing_parts();
-
-        let pos = pos.into();
-        let x_off = pos.x as usize;
-        let y_off = pos.y as usize;
-        let transform = convert_transform(state.transform);
-
-        let text = text.as_inner();
-
-        let layout = match layout.0 {
-            super::text::TextLayoutInner::Cosmic(ref layout) => layout,
+        let layout = match &layout.0 {
+            TextLayoutInner::Cosmic(ct) => ct,
             _ => {
-                tracing::warn!("TextLayout was not created by this backend");
+                self.mismatch_err = Err(piet::Error::NotSupported);
                 return;
             }
         };
-
-        // Draw the buffer into the pixmap.
-        let mut text_state = LineState::new();
-        text.with_font_system_mut(|fs| {
-            // Iterate and collect line states.
-            for (glyph, line_y) in layout.buffer().layout_runs().flat_map(|run| {
-                let y = run.line_y;
-                run.glyphs.iter().map(move |glyph| (glyph, y))
-            }) {
-                let color = match glyph.color_opt {
-                    Some(color) => {
-                        let [r, g, b, a] = [color.r(), color.g(), color.b(), color.a()];
-                        piet::Color::rgba8(r, g, b, a)
-                    }
-
-                    None => piet::util::DEFAULT_TEXT_COLOR,
-                };
-
-                text_state.handle_glyph(
-                    glyph,
-                    line_y - (f32::from_bits(glyph.cache_key.font_size_bits) * 0.9),
-                    color,
-                    false,
-                );
-            }
-
-            layout.buffer().draw(
-                fs,
-                &mut display.glyph_cache,
-                {
-                    let (r, g, b, a) = piet::util::DEFAULT_TEXT_COLOR.as_rgba8();
-                    CosmicColor::rgba(r, g, b, a)
-                },
-                |x, y, w, h, color| {
-                    let ts_color =
-                        tiny_skia::Color::from_rgba8(color.r(), color.g(), color.b(), color.a());
-
-                    buffer.fill_rect(
-                        tiny_skia::Rect::from_xywh(
-                            x_off as f32 + x as f32,
-                            y_off as f32 + y as f32,
-                            w as f32,
-                            h as f32,
-                        )
-                        .expect("invalid rect"),
-                        &tiny_skia::Paint {
-                            shader: tiny_skia::Shader::SolidColor(ts_color),
-                            ..Default::default()
-                        },
-                        transform,
-                        state.clip.as_ref(),
-                    );
-                },
-            )
-        });
-
-        // Draw the lines as well.
-        let line_width = 3.0;
-        for line in text_state.lines() {
-            if let Some(rect) = tiny_skia::Rect::from_ltrb(
-                line.start_x + x_off as f32,
-                line.y + y_off as f32,
-                line.end_x + x_off as f32,
-                line.y + line_width + y_off as f32,
-            ) {
-                let color = tiny_skia::Color::from_rgba8(
-                    line.style.color.red(),
-                    line.style.color.green(),
-                    line.style.color.blue(),
-                    line.style.color.alpha(),
-                );
-                buffer.fill_rect(
-                    rect,
-                    &tiny_skia::Paint {
-                        shader: tiny_skia::Shader::SolidColor(color),
-                        ..Default::default()
-                    },
-                    transform,
-                    state.clip.as_ref(),
-                );
-            }
-        }
+        self.inner().draw_text(layout, pos);
+        self.dirty = true;
     }
 
     pub(super) fn save(&mut self) -> Result<(), Error> {
-        self.render_states.push(Default::default());
-        Ok(())
+        self.inner().save()
     }
 
     pub(super) fn restore(&mut self) -> Result<(), Error> {
-        if self.render_states.len() <= 1 {
-            return Err(Error::StackUnbalance);
-        }
-
-        self.render_states.pop();
-        Ok(())
+        self.inner().restore()
     }
 
     pub(super) fn finish(&mut self) -> Result<(), Error> {
+        // Wrap and get the inner buffer.
+        let Buffer { mut buffer, .. } = self.inner.take().unwrap().into_target();
+
         // tiny-skia uses an RGBA format, while softbuffer uses XRGB. To convert, we need to
         // iterate over the pixels and shift the pixels over.
-        self.surface.buffer.iter_mut().for_each(|pixel| {
+        buffer.iter_mut().for_each(|pixel| {
             let [r, g, b, _] = pixel.to_ne_bytes();
             *pixel = (b as u32) | ((g as u32) << 8) | ((r as u32) << 16);
         });
 
         // Upload the buffer.
-        self.surface
-            .surface
-            .set_buffer(&self.surface.buffer, self.size.0 as _, self.size.1 as _);
+        buffer.present().unwrap();
 
         Ok(())
     }
 
     pub(super) fn transform(&mut self, transform: Affine) {
-        let (_, _, state, ..) = self.drawing_parts();
-        state.transform = transform * state.transform;
+        self.inner().transform(transform);
     }
 
     pub(super) fn make_image(
@@ -611,68 +272,12 @@ impl<'dsp, 'surf> RenderContext<'dsp, 'surf> {
         buf: &[u8],
         format: ImageFormat,
     ) -> Result<Image, Error> {
-        let buffer = match format {
-            ImageFormat::RgbaPremul => {
-                // This is the format that tiny-skia uses, so we can just use the buffer directly.
-                buf.to_vec()
-            }
-
-            ImageFormat::RgbaSeparate => {
-                let mut buffer = buf.to_vec();
-
-                // We need to premultiply the colors.
-                let colors = bytemuck::cast_slice_mut::<u8, [u8; 4]>(&mut buffer);
-                colors.iter_mut().for_each(|color| {
-                    let [r, g, b, a] = *color;
-                    let ts_color = ColorU8::from_rgba(r, g, b, a);
-                    let premul = ts_color.premultiply();
-                    let [r, g, b, a] =
-                        [premul.red(), premul.green(), premul.blue(), premul.alpha()];
-                    *color = [r, g, b, a];
-                });
-
-                buffer
-            }
-
-            ImageFormat::Rgb => {
-                // Add an alpha channel for every pixel.
-                bytemuck::cast_slice::<u8, [u8; 3]>(buf)
-                    .iter()
-                    .map(|[r, g, b]| ColorU8::from_rgba(*r, *g, *b, 0xFF).premultiply())
-                    .flat_map(|color| [color.red(), color.green(), color.blue(), color.alpha()])
-                    .collect()
-            }
-
-            ImageFormat::Grayscale => {
-                // Add an alpha channel for every pixel.
-                buf.iter()
-                    .map(|&v| ColorU8::from_rgba(v, v, v, 0xFF).premultiply())
-                    .flat_map(|color| [color.red(), color.green(), color.blue(), color.alpha()])
-                    .collect()
-            }
-
-            _ => {
-                return Err(Error::NotSupported);
-            }
-        };
-
-        let pixmap = Pixmap::from_vec(
-            buffer,
-            tiny_skia_path::IntSize::from_wh(width as _, height as _)
-                .ok_or_else(|| Error::InvalidInput)?,
-        )
-        .ok_or_else(|| Error::InvalidInput)?;
-
-        Ok(Image(pixmap))
+        self.inner().make_image(width, height, buf, format)
     }
 
     pub(super) fn draw_image(&mut self, image: &Image, dst_rect: Rect, interp: InterpolationMode) {
-        self.draw_image_area(
-            image,
-            Rect::new(0.0, 0.0, image.size().width, image.size().height),
-            dst_rect,
-            interp,
-        )
+        self.inner().draw_image(image, dst_rect, interp);
+        self.dirty = true;
     }
 
     pub(super) fn draw_image_area(
@@ -682,261 +287,21 @@ impl<'dsp, 'surf> RenderContext<'dsp, 'surf> {
         dst_rect: Rect,
         interp: InterpolationMode,
     ) {
-        // Create a transform to scale the image to the correct size.
-        let transform = convert_transform(
-            Affine::translate((-src_rect.x0, -src_rect.y0))
-                * Affine::translate((dst_rect.x0, dst_rect.y0))
-                * Affine::scale_non_uniform(
-                    dst_rect.width() / src_rect.width(),
-                    dst_rect.height() / src_rect.height(),
-                ),
-        );
-
-        // Create a pattern.
-        let pattern = tiny_skia::Pattern::new(
-            image.0.as_ref(),
-            tiny_skia::SpreadMode::Repeat,
-            match interp {
-                InterpolationMode::NearestNeighbor => tiny_skia::FilterQuality::Nearest,
-                InterpolationMode::Bilinear => tiny_skia::FilterQuality::Bilinear,
-            },
-            1.0,
-            transform,
-        );
-        let paint = Paint {
-            shader: pattern,
-            ..Default::default()
-        };
-
-        // Draw the image.
-        let (_, mut buffer, state, ..) = self.drawing_parts();
-        let transform = convert_transform(state.transform);
-        buffer.fill_rect(
-            convert_rect(dst_rect).unwrap(),
-            &paint,
-            transform,
-            state.clip.as_ref(),
-        );
+        self.inner()
+            .draw_image_area(image, src_rect, dst_rect, interp);
+        self.dirty = true;
     }
 
     pub(super) fn capture_image_area(&mut self, src_rect: Rect) -> Result<Image, Error> {
-        let (width, height) = (src_rect.width() as u32, src_rect.height() as u32);
-        let mut pixmap = Pixmap::new(width, height).ok_or_else(|| Error::InvalidInput)?;
-
-        // Copy the pixels from the surface.
-        let transform = convert_transform(
-            Affine::translate((src_rect.x0, src_rect.y0))
-                * Affine::scale_non_uniform(
-                    src_rect.width() / self.size.0 as f64,
-                    src_rect.height() / self.size.1 as f64,
-                ),
-        );
-
-        let (_, buffer, ..) = self.drawing_parts();
-        let shader = tiny_skia::Pattern::new(
-            buffer.as_ref(),
-            tiny_skia::SpreadMode::Pad,
-            tiny_skia::FilterQuality::Bilinear,
-            1.0,
-            transform,
-        );
-        let paint = tiny_skia::Paint {
-            shader,
-            ..Default::default()
-        };
-
-        pixmap
-            .fill_rect(
-                tiny_skia::Rect::from_xywh(0.0, 0.0, width as _, height as _).unwrap(),
-                &paint,
-                tiny_skia::Transform::identity(),
-                None,
-            )
-            .ok_or_else(|| Error::InvalidInput)?;
-
-        // Return the image.
-        Ok(Image(pixmap))
+        self.inner().capture_image_area(src_rect)
     }
 
     pub(super) fn blurred_rect(&mut self, _rect: Rect, _blur_radius: f64, _brush: &Brush) {
-        self.last_error = Err(Error::NotSupported);
+        self.inner().blurred_rect(_rect, _blur_radius, _brush);
+        self.dirty = true;
     }
 
     pub(super) fn current_transform(&self) -> Affine {
-        self.current_state().transform
+        self.inner.as_ref().unwrap().current_transform()
     }
 }
-
-impl Image {
-    pub(super) fn size(&self) -> Size {
-        let width = self.0.width() as f64;
-        let height = self.0.height() as f64;
-
-        Size::new(width, height)
-    }
-}
-
-struct LineState {
-    /// State for the underline.
-    underline: LineGenerator,
-
-    /// State for the strikethrough.
-    strikethrough: LineGenerator,
-
-    /// The lines to draw.
-    lines: Vec<LsLine>,
-}
-
-impl LineState {
-    fn new() -> Self {
-        Self {
-            underline: LineGenerator::new(LineType::Underline),
-            strikethrough: LineGenerator::new(LineType::StrikeThrough),
-            lines: Vec::new(),
-        }
-    }
-
-    fn handle_glyph(
-        &mut self,
-        glyph: &LayoutGlyph,
-        line_y: f32,
-        color: piet::Color,
-        is_bold: bool,
-    ) {
-        // Get the metadata.
-        let metadata = Metadata::from_raw(glyph.metadata);
-        let glyph = line_straddler::Glyph {
-            line_y,
-            font_size: f32::from_bits(glyph.cache_key.font_size_bits),
-            width: glyph.w,
-            x: glyph.x,
-            style: line_straddler::GlyphStyle {
-                bold: is_bold,
-                color: match glyph.color_opt {
-                    Some(color) => {
-                        let [r, g, b, a] = [color.r(), color.g(), color.b(), color.a()];
-
-                        line_straddler::Color::rgba(r, g, b, a)
-                    }
-
-                    None => {
-                        let (r, g, b, a) = color.as_rgba8();
-                        line_straddler::Color::rgba(r, g, b, a)
-                    }
-                },
-            },
-        };
-        let Self {
-            underline,
-            strikethrough,
-            lines,
-        } = self;
-
-        let handle_meta = |generator: &mut LineGenerator, has_it| {
-            if has_it {
-                generator.add_glyph(glyph)
-            } else {
-                generator.pop_line()
-            }
-        };
-
-        let underline = handle_meta(underline, metadata.underline());
-        let strikethrough = handle_meta(strikethrough, metadata.strikethrough());
-
-        lines.extend(underline);
-        lines.extend(strikethrough);
-    }
-
-    fn lines(&mut self) -> Vec<line_straddler::Line> {
-        // Pop the last lines.
-        let underline = self.underline.pop_line();
-        let strikethrough = self.strikethrough.pop_line();
-        self.lines.extend(underline);
-        self.lines.extend(strikethrough);
-
-        mem::take(&mut self.lines)
-    }
-}
-
-fn convert_transform(affine: Affine) -> tiny_skia::Transform {
-    let [a, b, c, d, e, f] = affine.as_coeffs();
-    tiny_skia::Transform::from_row(a as f32, b as f32, c as f32, d as f32, e as f32, f as f32)
-}
-
-fn convert_rect(rect: Rect) -> Option<tiny_skia::Rect> {
-    let x = rect.x0 as f32;
-    let y = rect.y0 as f32;
-    let width = rect.width() as f32;
-    let height = rect.height() as f32;
-
-    tiny_skia::Rect::from_xywh(x, y, width, height)
-}
-
-fn convert_point(point: Point) -> tiny_skia::Point {
-    tiny_skia::Point {
-        x: point.x as f32,
-        y: point.y as f32,
-    }
-}
-
-fn convert_color(color: piet::Color) -> tiny_skia::Color {
-    let (r, g, b, a) = color.as_rgba();
-    tiny_skia::Color::from_rgba(r as f32, g as f32, b as f32, a as f32).unwrap()
-}
-
-fn convert_shape(
-    builder: &mut PathBuilder,
-    shape: impl Shape,
-    tolerance: f64,
-    transform: Option<Affine>,
-) {
-    let transform = |pt: Point| {
-        if let Some(transform) = transform {
-            transform * pt
-        } else {
-            pt
-        }
-    };
-
-    shape.path_elements(tolerance).for_each(|el| match el {
-        PathEl::MoveTo(pt) => {
-            let pt = transform(pt);
-            builder.move_to(pt.x as f32, pt.y as f32);
-        }
-
-        PathEl::LineTo(pt) => {
-            let pt = transform(pt);
-            builder.line_to(pt.x as f32, pt.y as f32);
-        }
-
-        PathEl::QuadTo(p1, p2) => {
-            let p1 = transform(p1);
-            let p2 = transform(p2);
-            builder.quad_to(p1.x as f32, p1.y as f32, p2.x as f32, p2.y as f32);
-        }
-
-        PathEl::CurveTo(p1, p2, p3) => {
-            let p1 = transform(p1);
-            let p2 = transform(p2);
-            let p3 = transform(p3);
-            builder.cubic_to(
-                p1.x as f32,
-                p1.y as f32,
-                p2.x as f32,
-                p2.y as f32,
-                p3.x as f32,
-                p3.y as f32,
-            );
-        }
-
-        PathEl::ClosePath => {
-            builder.close();
-        }
-    })
-}
-
-fn convert_gradient_stop(stop: &piet::GradientStop) -> tiny_skia::GradientStop {
-    tiny_skia::GradientStop::new(stop.pos, convert_color(stop.color))
-}
-
-const STACK_UNBALANCE: &str = "Render state stack unbalance";

--- a/src/text.rs
+++ b/src/text.rs
@@ -7,7 +7,6 @@
 // * GNU Lesser General Public License as published by the Free Software Foundation, either
 // version 3 of the License, or (at your option) any later version.
 // * Mozilla Public License as published by the Mozilla Foundation, version 2.
-
 //
 // `theo` is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
@@ -16,7 +15,7 @@
 // You should have received a copy of the GNU Lesser General Public License and the Mozilla
 // Public License along with `theo`. If not, see <https://www.gnu.org/licenses/>.
 
-use piet_cosmic_text::{
+use piet_tiny_skia::{
     Text as CosmicText, TextLayout as CosmicTextLayout,
     TextLayoutBuilder as CosmicTextLayoutBuilder,
 };
@@ -34,16 +33,6 @@ use piet_wgpu::{
 /// The text backend for the system.
 #[derive(Clone)]
 pub struct Text(pub(crate) TextInner);
-
-impl Text {
-    #[allow(unreachable_patterns)]
-    pub(crate) fn as_inner(&self) -> &piet_cosmic_text::Text {
-        match &self.0 {
-            TextInner::Cosmic(inner) => inner,
-            _ => panic!(),
-        }
-    }
-}
 
 #[derive(Clone)]
 pub(crate) enum TextInner {

--- a/src/web_gl.rs
+++ b/src/web_gl.rs
@@ -7,7 +7,6 @@
 // * GNU Lesser General Public License as published by the Free Software Foundation, either
 // version 3 of the License, or (at your option) any later version.
 // * Mozilla Public License as published by the Mozilla Foundation, version 2.
-
 //
 // `theo` is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY;
 // without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
@@ -138,6 +137,10 @@ impl Display {
                 context: unsafe { GlContext::new(glow_ctx)? },
             })
         }
+    }
+
+    pub(super) async fn present(&mut self) {
+        // no-op
     }
 }
 


### PR DESCRIPTION
- Use piet-tiny-skia in swrast instead of a hand-rolled implementation
- Update to piet-wgpu 0.3 and wgpu 0.17
- Drop the CLA and the Patreon license

- [x] Tested on all platforms affected by this change

This PR adds a method, `present()`, which should be called when all desired windows have been drawn to. It makes sure that queues are submitted a limited number of times, which should close #10.

Closes #11 thanks to improvements in all of the `piet` implementations that I have made.